### PR TITLE
Fix Schedule

### DIFF
--- a/.github/workflows/sync-area-codes.yml
+++ b/.github/workflows/sync-area-codes.yml
@@ -3,7 +3,7 @@ name: Sync Area Codes
 on:
   schedule:
     # Update this just one time
-    - cron: '0 12 * * *'
+    - cron: '20 00 * * *'
 
 jobs:
   build:

--- a/.github/workflows/sync-area-codes.yml
+++ b/.github/workflows/sync-area-codes.yml
@@ -39,6 +39,7 @@ jobs:
         id: cpr
         uses: peter-evans/create-pull-request@v6
         with:
+          token: ${{ secrets.PAT }}
           commit-message: |
             Updated area codes list v${{ steps.check-for-changes.outputs.NEW_VERSION }}
 
@@ -59,5 +60,5 @@ jobs:
       - name: Enable Pull Request Automerge
         run: gh pr merge --squash --auto "${{ steps.cpr.outputs.pull-request-number }}"
         env:
-          GH_TOKEN: ${{ github.token }}
+          GH_TOKEN: ${{ secrets.PAT }}
         if: ${{ steps.cpr.outputs.pull-request-number }}

--- a/.github/workflows/sync-area-codes.yml
+++ b/.github/workflows/sync-area-codes.yml
@@ -2,6 +2,7 @@ name: Sync Area Codes
 
 on:
   schedule:
+    # Update this just one time
     - cron: '0 12 * * *'
 
 jobs:


### PR DESCRIPTION
- Permissions to kick off the next pending workflow does not work for `GITHUB_TOKEN`
- PAT are needed instead